### PR TITLE
add firebase requirement to CommonJS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
+require('firebase');
 require('./dist/angularfire');
 module.exports = 'firebase';


### PR DESCRIPTION
The idea of this pull request is to simplify the development of apps using firebase and angularfire with browserify. Instead of requesting to the programmer add two explicit dependences (one direct and other required by the former), it translates to angularfire the responsability to load firebase dependence (the latter).

Before this commit, using browserify, in order to use angularfire the programmer must do:

``` bash
$ npm install --save firebase angularfire
```

``` javascript
require('firebase');
require('angularfire');
```

With this commit applied, the programmer can drop the direct dependence with firebase:

``` bash
$ npm install --save angularfire
```

``` javascript
require('angularfire');
```

No more dependences or worries are added.
